### PR TITLE
Enable merge queue and update renovate config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Build and Check
 
 on:
   push:
+  merge_group:
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,10 @@ name: Build and Check
 
 on:
   push:
+    branches:
+      - main
   merge_group:
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -2,6 +2,7 @@ name: Cypress UI tests
 
 on:
   push:
+  merge_group:
 
 jobs:
   cypress-run:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -2,7 +2,10 @@ name: Cypress UI tests
 
 on:
   push:
+    branches:
+      - main
   merge_group:
+  pull_request:
 
 jobs:
   cypress-run:

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,23 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>graasp/renovate-config:app"
-  ]
+  ],
+  "assignees": ["swouf"],
+  "reviewers": ["swouf"],
+  "packageRules": [
+    {
+      "matchDepTypes": ["devDependencies"],
+      "matchPackagePatterns": ["lint", "prettier", "vite", "cypress", "commitlint", "axios", "concurrently", "env"],
+      "automerge": true
+    },
+    {
+      "matchUpdateTypes": ["minor","patch"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
+    }
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true
+  }
 }


### PR DESCRIPTION
I changed the renovate config to automerge most updates. Moreover, I changed the workflows to build and test to trigger on merge groups, which allows us to use merge queues in this repo. This is more efficient when you merge multiple PRs.