### PR TITLE
fix: use a fixed id for the item

### DIFF
--- a/src/mocks/db.ts
+++ b/src/mocks/db.ts
@@ -26,6 +26,7 @@ export const mockMembers: CompleteMember[] = [
 ];
 
 export const mockItem: DiscriminatedItem = AppItemFactory({
+  id: 'd5356ad1-e42b-466f-b3a1-c559afaf1903',
   name: 'app-starter-ts-vite',
   extra: { [ItemType.APP]: { url: 'http://localhost:3002' } },
   creator: mockMembers[0],


### PR DESCRIPTION
This should ensure we keep the same `id` for the item, otherwise since the IndexedDB does not get reset, the item ids do not match and the user gets a 500 error.